### PR TITLE
Removed startEmission from StakingRewards & added tests for monthly staking periods

### DIFF
--- a/contracts/tvl-staking/RibbonDualStakingRewards.sol
+++ b/contracts/tvl-staking/RibbonDualStakingRewards.sol
@@ -220,7 +220,7 @@ contract DualStakingRewards is
   }
 
   function _weeksPassed() internal view returns (uint256) {
-    return block.timestamp.div(1 weeks).add(1).mul(1 weeks);
+    return block.timestamp.div(1 weeks).mul(1 weeks);
   }
 
   /* ========== RESTRICTED FUNCTIONS ========== */
@@ -233,11 +233,11 @@ contract DualStakingRewards is
   {
     Rewards memory _rewardRate;
     uint256 _rewardsDuration = rewardsDuration;
-    if (_weeksPassed() >= periodFinish) {
+    if (block.timestamp >= periodFinish) {
       _rewardRate.token0 = reward0.div(_rewardsDuration).toUint128();
       _rewardRate.token1 = reward1.div(_rewardsDuration).toUint128();
     } else {
-      uint256 remaining = periodFinish.sub(_weeksPassed());
+      uint256 remaining = periodFinish.sub(block.timestamp);
       _rewardRate = rewardRate;
       _rewardRate.token0 = reward0
         .add(remaining.mul(_rewardRate.token0))

--- a/contracts/tvl-staking/RibbonDualStakingRewards.sol
+++ b/contracts/tvl-staking/RibbonDualStakingRewards.sol
@@ -319,6 +319,5 @@ contract DualStakingRewards is
   event Withdrawn(address indexed user, uint256 amount);
   event RewardPaid(address indexed token, address indexed user, uint256 reward);
   event RewardsDurationUpdated(uint256 newDuration);
-  event StartEmissionUpdated(uint256 StartEmissionUpdated);
   event Recovered(address token, uint256 amount);
 }

--- a/contracts/tvl-staking/RibbonDualStakingRewards.sol
+++ b/contracts/tvl-staking/RibbonDualStakingRewards.sol
@@ -98,7 +98,7 @@ contract DualStakingRewards is
 
   // The minimum between periodFinish and the last instance of the current startEmission release time
   function lastTimeRewardApplicable() public view override returns (uint256) {
-    return Math.min(_numWeeksPassed().mul(1 weeks), periodFinish);
+    return Math.min(_numWeeksPassed(), periodFinish);
   }
 
   function rewardPerToken() public view override returns (uint256, uint256) {
@@ -220,7 +220,7 @@ contract DualStakingRewards is
   }
 
   function _numWeeksPassed() internal view returns (uint256) {
-    return block.timestamp.div(1 weeks);
+    return block.timestamp.div(1 weeks).mul(1 weeks);
   }
 
   /* ========== RESTRICTED FUNCTIONS ========== */
@@ -265,7 +265,7 @@ contract DualStakingRewards is
     );
 
     rewardRate = _rewardRate;
-    uint256 timestamp = _numWeeksPassed().mul(1 weeks);
+    uint256 timestamp = _numWeeksPassed();
     periodFinish = timestamp.add(rewardsDuration);
     lastUpdateTime = timestamp;
     emit RewardAdded(address(rewardsToken0), reward0);

--- a/contracts/tvl-staking/RibbonDualStakingRewards.sol
+++ b/contracts/tvl-staking/RibbonDualStakingRewards.sol
@@ -46,9 +46,6 @@ contract DualStakingRewards is
   mapping(address => Rewards) public userRewardPerTokenPaid;
   mapping(address => Rewards) public rewards;
 
-  // The last timestamp at which a user staked
-  mapping(address => uint256) public checkpoint;
-
   uint256 private _totalSupply;
   mapping(address => uint256) private _balances;
 
@@ -195,7 +192,6 @@ contract DualStakingRewards is
     require(amount > 0, "Cannot stake 0");
     _totalSupply = _totalSupply.add(amount);
     _balances[account] = _balances[account].add(amount);
-    checkpoint[account] = block.timestamp;
     stakingToken.safeTransferFrom(msg.sender, address(this), amount);
     emit Staked(account, msg.sender, amount);
   }
@@ -209,12 +205,7 @@ contract DualStakingRewards is
     require(amount > 0, "Cannot withdraw 0");
     _totalSupply = _totalSupply.sub(amount);
     _balances[msg.sender] = _balances[msg.sender].sub(amount);
-    if (
-      block.timestamp <
-      Math.min(checkpoint[msg.sender].add(rewardsDuration), periodFinish).add(
-        1 days
-      )
-    ) {
+    if (block.timestamp < periodFinish.add(1 days)) {
       delete rewards[msg.sender];
     }
     stakingToken.safeTransfer(msg.sender, amount);
@@ -222,12 +213,7 @@ contract DualStakingRewards is
   }
 
   function getReward() public override nonReentrant updateReward(msg.sender) {
-    if (
-      block.timestamp >=
-      Math.min(checkpoint[msg.sender].add(rewardsDuration), periodFinish).add(
-        1 days
-      )
-    ) {
+    if (block.timestamp >= periodFinish.add(1 days)) {
       Rewards memory _rewards = rewards[msg.sender];
       if (_rewards.token0 > 0) {
         rewardsToken0.safeTransfer(

--- a/contracts/tvl-staking/RibbonDualStakingRewards.sol
+++ b/contracts/tvl-staking/RibbonDualStakingRewards.sol
@@ -98,7 +98,7 @@ contract DualStakingRewards is
 
   // The minimum between periodFinish and the last instance of the current startEmission release time
   function lastTimeRewardApplicable() public view override returns (uint256) {
-    return Math.min(_weeksPassed(), periodFinish);
+    return Math.min(_numWeeksPassed().mul(1 weeks), periodFinish);
   }
 
   function rewardPerToken() public view override returns (uint256, uint256) {
@@ -219,8 +219,8 @@ contract DualStakingRewards is
     getReward();
   }
 
-  function _weeksPassed() internal view returns (uint256) {
-    return block.timestamp.div(1 weeks).mul(1 weeks);
+  function _numWeeksPassed() internal view returns (uint256) {
+    return block.timestamp.div(1 weeks);
   }
 
   /* ========== RESTRICTED FUNCTIONS ========== */
@@ -265,8 +265,9 @@ contract DualStakingRewards is
     );
 
     rewardRate = _rewardRate;
-    periodFinish = _weeksPassed().add(rewardsDuration);
-    lastUpdateTime = _weeksPassed();
+    uint256 timestamp = _numWeeksPassed().mul(1 weeks);
+    periodFinish = timestamp.add(rewardsDuration);
+    lastUpdateTime = timestamp;
     emit RewardAdded(address(rewardsToken0), reward0);
     emit RewardAdded(address(rewardsToken1), reward1);
   }

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -43,8 +43,7 @@ describe("DualStakingRewards contract", function () {
     stakingTokenOwner: Contract,
     externalRewardsToken: Contract,
     externalRewardsTokenOwner: Contract,
-    stakingRewards: Contract,
-    startEmission: string;
+    stakingRewards: Contract;
 
   addSnapshotBeforeRestoreAfterEach();
 
@@ -90,8 +89,6 @@ describe("DualStakingRewards contract", function () {
       EXTERNAL_TOKEN_PARAMS.ADDRESS
     );
 
-    startEmission = ((await currentTime()) + 1000).toString();
-
     // Get staking rewards contract
     RibbonDualStakingRewards = await ethers.getContractFactory(
       "DualStakingRewards"
@@ -101,8 +98,7 @@ describe("DualStakingRewards contract", function () {
       mockRewardsDistributionAddress.address,
       rewardsToken0.address,
       rewardsToken1.address,
-      STAKING_REWARDS_rETHTHETA_PARAMS.STAKING_TOKEN,
-      startEmission
+      STAKING_REWARDS_rETHTHETA_PARAMS.STAKING_TOKEN
     );
 
     await owner.sendTransaction({
@@ -181,7 +177,6 @@ describe("DualStakingRewards contract", function () {
         "setPaused",
         "setRewardsDistribution",
         "setRewardsDuration",
-        "setStartEmission",
         "recoverERC20",
       ],
     });
@@ -212,11 +207,6 @@ describe("DualStakingRewards contract", function () {
         rewardsDistributionAddress,
         mockRewardsDistributionAddress.address
       );
-    });
-
-    it("should set start emission on constructor", async () => {
-      const startEmissionTimestamp = await stakingRewards.startEmission();
-      assert.equal(startEmissionTimestamp, startEmission);
     });
   });
 
@@ -365,13 +355,19 @@ describe("DualStakingRewards contract", function () {
 
     describe("when updated", () => {
       it("should equal last emission time", async () => {
-        await stakingRewards
+        const tx = await stakingRewards
           .connect(mockRewardsDistributionAddress)
           .notifyRewardAmount(toUnit("1"), toUnit("1"));
 
+        const weeksPassed = BigNumber.from(
+          (await provider.getBlock(tx.blockNumber)).timestamp
+        )
+          .div(DAY * 7)
+          .add(1)
+          .mul(DAY * 7);
         const lastTimeReward = await stakingRewards.lastTimeRewardApplicable();
 
-        assert.equal(startEmission, lastTimeReward.toString());
+        assert.equal(weeksPassed.toString(), lastTimeReward.toString());
       });
     });
   });
@@ -490,7 +486,7 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       const rewardPerToken = await stakingRewards.rewardPerToken();
 
@@ -726,8 +722,8 @@ describe("DualStakingRewards contract", function () {
 
       const earned = await stakingRewards.earned(deployerAccount.address);
 
-      assert.bnGt(earned[0], toUnit("999.999"));
-      assert.bnGt(earned[1], toUnit("999.999"));
+      assert.bnGt(earned[0], toUnit("499.999"));
+      assert.bnGt(earned[1], toUnit("599.999"));
     });
 
     it("should be same after emission hit + 1 day", async () => {
@@ -778,7 +774,7 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       const earned = await stakingRewards.earned(deployerAccount.address);
 
@@ -822,7 +818,7 @@ describe("DualStakingRewards contract", function () {
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       await stakingRewards.connect(owner).stake(totalToStake);
 
@@ -926,7 +922,7 @@ describe("DualStakingRewards contract", function () {
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 22);
+      await fastForward(DAY * 28);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
 
       assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(98).div(100));
@@ -975,7 +971,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(3).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(3).div(4));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 5);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1014,7 +1010,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(2));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(2));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 5);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1054,7 +1050,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(4));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 5);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1083,13 +1079,13 @@ describe("DualStakingRewards contract", function () {
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 4);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
       assert.bnEqual(deployerEarned[0], rewardValue0.mul(0).div(4));
       assert.bnEqual(deployerEarned[1], rewardValue1.mul(0).div(4));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 1);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1196,7 +1192,7 @@ describe("DualStakingRewards contract", function () {
   describe("getReward()", () => {
     const seventyDays = DAY * 70;
 
-    it("rewards balance should remain unchanged if getting reward BEFORE end of program", async () => {
+    it("rewards balance should change if getting reward BEFORE end of program", async () => {
       const totalToStake = toUnit("100");
       const totalToDistribute0 = toUnit("5000");
       const totalToDistribute1 = toUnit("6000");
@@ -1244,25 +1240,25 @@ describe("DualStakingRewards contract", function () {
         deployerAccount.address
       );
 
-      assert.isAbove(
+      assert.equal(
         parseInt(postEarnedBal[0].toString()),
         parseInt(initialEarnedBal[0].toString())
       );
-      assert.isAbove(
+      assert.equal(
         parseInt(postEarnedBal[1].toString()),
         parseInt(initialEarnedBal[1].toString())
       );
-      assert.equal(
+      assert.isAbove(
         parseInt(postReward0Bal.toString()),
         parseInt(initialReward0Bal.toString())
       );
-      assert.equal(
+      assert.isAbove(
         parseInt(postReward1Bal.toString()),
         parseInt(initialReward1Bal.toString())
       );
     });
 
-    it("rewards balance should remain unchanged if getting reward BEFORE end of program", async () => {
+    it("rewards balance should changed if getting reward BEFORE end of program", async () => {
       const totalToStake = toUnit("100");
       const totalToDistribute0 = toUnit("5000");
       const totalToDistribute1 = toUnit("6000");
@@ -1315,19 +1311,19 @@ describe("DualStakingRewards contract", function () {
         `post reward bal is ${postReward0Bal.toString()}, ${postReward1Bal.toString()}`
       );
 
-      assert.isAbove(
+      assert.equal(
         parseInt(postEarnedBal[0].toString()),
         parseInt(initialEarnedBal[0].toString())
       );
-      assert.isAbove(
+      assert.equal(
         parseInt(postEarnedBal[1].toString()),
         parseInt(initialEarnedBal[1].toString())
       );
-      assert.equal(
+      assert.isAbove(
         parseInt(postReward0Bal.toString()),
         parseInt(initialReward0Bal.toString())
       );
-      assert.equal(
+      assert.isAbove(
         parseInt(postReward1Bal.toString()),
         parseInt(initialReward1Bal.toString())
       );
@@ -1440,6 +1436,7 @@ describe("DualStakingRewards contract", function () {
         "Previous rewards period must be complete before changing the duration for the new period"
       );
     });
+
     it("should update when setting setRewardsDuration after the period has finished", async () => {
       const totalToStake = toUnit("100");
       const totalToDistribute0 = toUnit("5000");
@@ -1463,7 +1460,7 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(totalToDistribute0, totalToDistribute1);
 
-      await fastForward(DAY * 31);
+      await fastForward(DAY * 35);
 
       await expect(
         stakingRewards.connect(owner).setRewardsDuration(seventyDays)
@@ -1502,7 +1499,7 @@ describe("DualStakingRewards contract", function () {
 
       await fastForward(DAY * 4);
       await stakingRewards.connect(deployerAccount).getReward();
-      await fastForward(DAY * 27);
+      await fastForward(DAY * 31);
 
       // New Rewards period much lower
       await rewardsToken0Owner.transfer(
@@ -1526,28 +1523,6 @@ describe("DualStakingRewards contract", function () {
 
       await fastForward(DAY * 71);
       await stakingRewards.connect(deployerAccount).getReward();
-    });
-  });
-
-  describe("setStartEmission()", () => {
-    it("should change the start emission", async () => {
-      let newStartEmission = ((await currentTime()) + 1000).toString();
-
-      await stakingRewards.connect(owner).setStartEmission(newStartEmission);
-
-      await expect(
-        stakingRewards.connect(owner).setStartEmission(newStartEmission)
-      ).to.emit(stakingRewards, "StartEmissionUpdated");
-
-      assert.equal(await stakingRewards.startEmission(), newStartEmission);
-    });
-    it("should revert when setting setRewardsDuration before the period has finished", async () => {
-      let newStartEmission = ((await currentTime()) - 1000).toString();
-
-      await assert.revert(
-        stakingRewards.connect(owner).setStartEmission(newStartEmission),
-        "Start emission must be in the future"
-      );
     });
   });
 
@@ -1585,7 +1560,7 @@ describe("DualStakingRewards contract", function () {
         .reverted;
     });
 
-    it("should set rewards to 0 if withdrawing BEFORE end of mining program", async () => {
+    it("rewards should remain unchanged if withdrawing BEFORE end of mining program", async () => {
       const totalToStake = toUnit("100");
       const totalToDistribute0 = toUnit("5000");
       const totalToDistribute1 = toUnit("6000");
@@ -1615,8 +1590,8 @@ describe("DualStakingRewards contract", function () {
       const deployerRewards = await stakingRewards.rewards(
         deployerAccount.address
       );
-      assert.equal(BigNumber.from(0), deployerRewards[0].toString());
-      assert.equal(BigNumber.from(0), deployerRewards[1].toString());
+      assert.bnLt(BigNumber.from(0), deployerRewards[0]);
+      assert.bnLt(BigNumber.from(0), deployerRewards[1]);
     });
 
     it("rewards should remain unchanged if withdrawing AFTER end of mining program", async () => {
@@ -1767,8 +1742,7 @@ describe("DualStakingRewards contract", function () {
         mockRewardsDistributionAddress.address,
         rewardsToken0.address,
         rewardsToken1.address,
-        STAKING_REWARDS_rETHTHETA_PARAMS.STAKING_TOKEN,
-        startEmission
+        STAKING_REWARDS_rETHTHETA_PARAMS.STAKING_TOKEN
       );
 
       await localStakingRewards
@@ -1869,7 +1843,7 @@ describe("DualStakingRewards contract", function () {
       await fastForward(DAY * 7);
 
       const earned1 = await stakingRewards.earned(deployerAccount.address);
-      assert.bnGt(earned1[0], toUnit("2143.33"));
+      assert.bnGt(earned1[0], toUnit("1874.99"));
       assert.bnGt(earned1[1], toUnit("1499.99"));
     });
 
@@ -1884,10 +1858,7 @@ describe("DualStakingRewards contract", function () {
       const month = DAY * 30;
 
       await stakingRewards.connect(owner).setRewardsDuration(rewardsDuration);
-
-      await stakingRewards
-        .connect(owner)
-        .setStartEmission((await currentTime()) + 1000);
+      await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
       const rewardValue0 = toUnit(5000);
       const rewardValue1 = toUnit(6000);
@@ -1897,19 +1868,13 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
 
-      await stakingRewards.connect(deployerAccount).stake(totalToStake);
-
       await fastForward(month);
 
       const rewardRate0 = await stakingRewards.rewardRate();
       const earned0 = await stakingRewards.earned(deployerAccount.address);
 
-      await stakingRewards
-        .connect(owner)
-        .setStartEmission((await currentTime()) + 1000);
-
       await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue0);
-      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue0);
+      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue1);
       await stakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -970,7 +970,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(3).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(3).div(4));
 
-      await fastForward(DAY * 5);
+      await fastForward(DAY * 2);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1009,7 +1009,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(2));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(2));
 
-      await fastForward(DAY * 5);
+      await fastForward(DAY * 2);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1049,7 +1049,7 @@ describe("DualStakingRewards contract", function () {
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(4));
 
-      await fastForward(DAY * 5);
+      await fastForward(DAY * 2);
 
       const newDeployerEarned = await stakingRewards.earned(
         deployerAccount.address
@@ -1074,15 +1074,15 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
 
-      await fastForward(DAY * 22);
+      await fastForward(DAY * 18);
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 4);
+      await fastForward(DAY * 1);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
-      assert.bnEqual(deployerEarned[0], rewardValue0.mul(0).div(4));
-      assert.bnEqual(deployerEarned[1], rewardValue1.mul(0).div(4));
+      assert.bnEqual(deployerEarned[0], BigNumber.from(0));
+      assert.bnEqual(deployerEarned[1], BigNumber.from(0));
 
       await fastForward(DAY * 1);
 
@@ -1589,8 +1589,8 @@ describe("DualStakingRewards contract", function () {
       const deployerRewards = await stakingRewards.rewards(
         deployerAccount.address
       );
-      assert.bnGt(deployerRewards[0], BigNumber.from(0));
-      assert.bnGt(deployerRewards[1], BigNumber.from(0));
+      assert.bnLt(BigNumber.from(0), deployerRewards[0]);
+      assert.bnLt(BigNumber.from(0), deployerRewards[1]);
     });
 
     it("rewards should remain unchanged if withdrawing AFTER end of mining program", async () => {

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -1872,5 +1872,54 @@ describe("DualStakingRewards contract", function () {
       assert.bnGt(earned1[0], toUnit("2143.33"));
       assert.bnGt(earned1[1], toUnit("1499.99"));
     });
+
+    it("Should create monthly staking periods", async () => {
+      const totalToStake = toUnit("100");
+      await stakingTokenOwner.transfer(deployerAccount.address, totalToStake);
+      await stakingToken
+        .connect(deployerAccount)
+        .approve(stakingRewards.address, totalToStake);
+
+      const rewardsDuration = DAY * 26;
+      const month = DAY * 30;
+
+      await stakingRewards.connect(owner).setRewardsDuration(rewardsDuration);
+
+      await stakingRewards
+        .connect(owner)
+        .setStartEmission((await currentTime()) + 1000);
+
+      const rewardValue0 = toUnit(5000);
+      const rewardValue1 = toUnit(6000);
+      await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue0);
+      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue1);
+      await stakingRewards
+        .connect(mockRewardsDistributionAddress)
+        .notifyRewardAmount(rewardValue0, rewardValue1);
+
+      await stakingRewards.connect(deployerAccount).stake(totalToStake);
+
+      await fastForward(month);
+
+      console.log(await stakingRewards.rewardRate());
+      console.log(await stakingRewards.earned(deployerAccount.address));
+
+      await stakingRewards
+        .connect(owner)
+        .setStartEmission((await currentTime()) + 1000);
+
+      const rewardValue2 = toUnit(5000);
+      const rewardValue3 = toUnit(6000);
+      await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue2);
+      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue3);
+      await stakingRewards
+        .connect(mockRewardsDistributionAddress)
+        .notifyRewardAmount(rewardValue2, rewardValue3);
+
+      await fastForward(month);
+
+      console.log(await stakingRewards.rewardRate());
+      console.log(await stakingRewards.earned(deployerAccount.address));
+    });
   });
 });

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -911,8 +911,6 @@ describe("DualStakingRewards contract", function () {
         .connect(deployerAccount)
         .approve(stakingRewards.address, totalToStake);
 
-      await stakingRewards.connect(deployerAccount).stake(totalToStake);
-
       const rewardValue0 = toUnit(5000);
       const rewardValue1 = toUnit(6000);
       await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue0);
@@ -920,6 +918,8 @@ describe("DualStakingRewards contract", function () {
       await stakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
+
+      await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
       await fastForward(DAY * 28);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
@@ -964,8 +964,8 @@ describe("DualStakingRewards contract", function () {
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
 
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(270).div(400));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(270).div(400));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(298).div(400));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(298).div(400));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(3).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(3).div(4));
@@ -1003,8 +1003,8 @@ describe("DualStakingRewards contract", function () {
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(80).div(200));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(80).div(200));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(98).div(200));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(98).div(200));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(2));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(2));
@@ -1043,8 +1043,8 @@ describe("DualStakingRewards contract", function () {
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
 
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(80).div(400));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(80).div(400));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(98).div(400));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(98).div(400));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(4));
@@ -1459,7 +1459,7 @@ describe("DualStakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(totalToDistribute0, totalToDistribute1);
 
-      await fastForward(DAY * 35);
+      await fastForward(DAY * 31);
 
       await expect(
         stakingRewards.connect(owner).setRewardsDuration(seventyDays)
@@ -1498,7 +1498,7 @@ describe("DualStakingRewards contract", function () {
 
       await fastForward(DAY * 4);
       await stakingRewards.connect(deployerAccount).getReward();
-      await fastForward(DAY * 31);
+      await fastForward(DAY * 27);
 
       // New Rewards period much lower
       await rewardsToken0Owner.transfer(
@@ -1589,8 +1589,8 @@ describe("DualStakingRewards contract", function () {
       const deployerRewards = await stakingRewards.rewards(
         deployerAccount.address
       );
-      assert.bnLt(BigNumber.from(0), deployerRewards[0]);
-      assert.bnLt(BigNumber.from(0), deployerRewards[1]);
+      assert.bnGt(deployerRewards[0], BigNumber.from(0));
+      assert.bnGt(deployerRewards[1], BigNumber.from(0));
     });
 
     it("rewards should remain unchanged if withdrawing AFTER end of mining program", async () => {
@@ -1774,43 +1774,43 @@ describe("DualStakingRewards contract", function () {
     it("Reverts if the provided reward is greater than the balance, plus rolled-over balance", async () => {
       const rewardValue0 = toUnit(1000);
       const rewardValue1 = toUnit(2000);
-      const rewardsToken0Balance0 = await rewardsToken0.balanceOf(
+      let rewardsToken0Balance = await rewardsToken0.balanceOf(
         localStakingRewards.address
       );
-      if (rewardValue0 > rewardsToken0Balance0) {
+      if (rewardValue0.gt(rewardsToken0Balance)) {
         await rewardsToken0Owner.transfer(
           localStakingRewards.address,
-          rewardValue0.sub(rewardsToken0Balance0)
+          rewardValue0.sub(rewardsToken0Balance)
         );
       }
-      const rewardsToken1Balance0 = await rewardsToken1.balanceOf(
+      let rewardsToken1Balance = await rewardsToken1.balanceOf(
         localStakingRewards.address
       );
-      if (rewardValue1 > rewardsToken1Balance0) {
+      if (rewardValue1.gt(rewardsToken1Balance)) {
         await rewardsToken1Owner.transfer(
           localStakingRewards.address,
-          rewardValue1.sub(rewardsToken1Balance0)
+          rewardValue1.sub(rewardsToken1Balance)
         );
       }
       localStakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
-      const rewardsToken0Balance1 = await rewardsToken0.balanceOf(
+      rewardsToken0Balance = await rewardsToken0.balanceOf(
         localStakingRewards.address
       );
-      if (rewardValue0 > rewardsToken0Balance1) {
+      if (rewardValue0.gt(rewardsToken0Balance)) {
         await rewardsToken0Owner.transfer(
           localStakingRewards.address,
-          rewardValue0.sub(rewardsToken0Balance1)
+          rewardValue0.sub(rewardsToken0Balance)
         );
       }
-      const rewardsToken1Balance1 = await rewardsToken1.balanceOf(
+      rewardsToken1Balance = await rewardsToken1.balanceOf(
         localStakingRewards.address
       );
-      if (rewardValue1 > rewardsToken1Balance1) {
+      if (rewardValue1.gt(rewardsToken1Balance)) {
         await rewardsToken1Owner.transfer(
           localStakingRewards.address,
-          rewardValue1.sub(rewardsToken1Balance1)
+          rewardValue1.sub(rewardsToken1Balance)
         );
       }
       // Now take into account any leftover quantity.

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -363,7 +363,6 @@ describe("DualStakingRewards contract", function () {
           (await provider.getBlock(tx.blockNumber)).timestamp
         )
           .div(DAY * 7)
-          .add(1)
           .mul(DAY * 7);
         const lastTimeReward = await stakingRewards.lastTimeRewardApplicable();
 
@@ -912,6 +911,8 @@ describe("DualStakingRewards contract", function () {
         .connect(deployerAccount)
         .approve(stakingRewards.address, totalToStake);
 
+      await stakingRewards.connect(deployerAccount).stake(totalToStake);
+
       const rewardValue0 = toUnit(5000);
       const rewardValue1 = toUnit(6000);
       await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue0);
@@ -919,8 +920,6 @@ describe("DualStakingRewards contract", function () {
       await stakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
-
-      await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
       await fastForward(DAY * 28);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
@@ -965,8 +964,8 @@ describe("DualStakingRewards contract", function () {
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
 
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(298).div(400));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(298).div(400));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(270).div(400));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(270).div(400));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(3).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(3).div(4));
@@ -1004,8 +1003,8 @@ describe("DualStakingRewards contract", function () {
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(98).div(200));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(98).div(200));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(80).div(200));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(80).div(200));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(2));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(2));
@@ -1044,8 +1043,8 @@ describe("DualStakingRewards contract", function () {
 
       console.log(deployerEarned[0].toString(), deployerEarned[1].toString());
 
-      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(98).div(400));
-      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(98).div(400));
+      assertBNGreaterThan(deployerEarned[0], rewardValue0.mul(80).div(400));
+      assertBNGreaterThan(deployerEarned[1], rewardValue1.mul(80).div(400));
 
       assertBNLessThan(deployerEarned[0], rewardValue0.mul(1).div(4));
       assertBNLessThan(deployerEarned[1], rewardValue1.mul(1).div(4));
@@ -1772,35 +1771,55 @@ describe("DualStakingRewards contract", function () {
       );
     });
 
-    it("Reverts if the provided reward is greater than the balance, plus rolled-over balance.", async () => {
+    it("Reverts if the provided reward is greater than the balance, plus rolled-over balance", async () => {
       const rewardValue0 = toUnit(1000);
       const rewardValue1 = toUnit(2000);
-      await rewardsToken0Owner.transfer(
-        localStakingRewards.address,
-        rewardValue0
+      const rewardsToken0Balance0 = await rewardsToken0.balanceOf(
+        localStakingRewards.address
       );
-      await rewardsToken1Owner.transfer(
-        localStakingRewards.address,
-        rewardValue1
+      if (rewardValue0 > rewardsToken0Balance0) {
+        await rewardsToken0Owner.transfer(
+          localStakingRewards.address,
+          rewardValue0.sub(rewardsToken0Balance0)
+        );
+      }
+      const rewardsToken1Balance0 = await rewardsToken1.balanceOf(
+        localStakingRewards.address
       );
+      if (rewardValue1 > rewardsToken1Balance0) {
+        await rewardsToken1Owner.transfer(
+          localStakingRewards.address,
+          rewardValue1.sub(rewardsToken1Balance0)
+        );
+      }
       localStakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue0, rewardValue1);
-      await rewardsToken0Owner.transfer(
-        localStakingRewards.address,
-        rewardValue0
+      const rewardsToken0Balance1 = await rewardsToken0.balanceOf(
+        localStakingRewards.address
       );
-      await rewardsToken1Owner.transfer(
-        localStakingRewards.address,
-        rewardValue1
+      if (rewardValue0 > rewardsToken0Balance1) {
+        await rewardsToken0Owner.transfer(
+          localStakingRewards.address,
+          rewardValue0.sub(rewardsToken0Balance1)
+        );
+      }
+      const rewardsToken1Balance1 = await rewardsToken1.balanceOf(
+        localStakingRewards.address
       );
+      if (rewardValue1 > rewardsToken1Balance1) {
+        await rewardsToken1Owner.transfer(
+          localStakingRewards.address,
+          rewardValue1.sub(rewardsToken1Balance1)
+        );
+      }
       // Now take into account any leftover quantity.
       await assert.revert(
         localStakingRewards
           .connect(mockRewardsDistributionAddress)
           .notifyRewardAmount(
             rewardValue0.add(toUnit(0.1)),
-            rewardValue0.add(toUnit(0.1))
+            rewardValue1.add(toUnit(0.1))
           ),
         "Provided reward0 too high"
       );
@@ -1843,7 +1862,7 @@ describe("DualStakingRewards contract", function () {
       await fastForward(DAY * 7);
 
       const earned1 = await stakingRewards.earned(deployerAccount.address);
-      assert.bnGt(earned1[0], toUnit("1874.99"));
+      assert.bnGt(earned1[0], toUnit("1843.58"));
       assert.bnGt(earned1[1], toUnit("1499.99"));
     });
 

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -1907,6 +1907,28 @@ describe("DualStakingRewards contract", function () {
       assert.bnEqual(rewardRate0[1], rewardRate1[1]);
       assert.bnEqual(earned1[0].sub(earned0[0]), earned0[0]);
       assert.bnEqual(earned1[1].sub(earned0[1]), earned0[1]);
+
+      const rewardsToken0Balance = await rewardsToken0.balanceOf(
+        deployerAccount.address
+      );
+      const rewardsToken1Balance = await rewardsToken1.balanceOf(
+        deployerAccount.address
+      );
+
+      await stakingRewards.connect(deployerAccount).getReward();
+
+      assert.bnEqual(
+        (await rewardsToken0.balanceOf(deployerAccount.address)).sub(
+          rewardsToken0Balance
+        ),
+        earned1[0]
+      );
+      assert.bnEqual(
+        (await rewardsToken1.balanceOf(deployerAccount.address)).sub(
+          rewardsToken1Balance
+        ),
+        earned1[1]
+      );
     });
   });
 });

--- a/test/DualStakingRewards.ts
+++ b/test/DualStakingRewards.ts
@@ -1901,25 +1901,28 @@ describe("DualStakingRewards contract", function () {
 
       await fastForward(month);
 
-      console.log(await stakingRewards.rewardRate());
-      console.log(await stakingRewards.earned(deployerAccount.address));
+      const rewardRate0 = await stakingRewards.rewardRate();
+      const earned0 = await stakingRewards.earned(deployerAccount.address);
 
       await stakingRewards
         .connect(owner)
         .setStartEmission((await currentTime()) + 1000);
 
-      const rewardValue2 = toUnit(5000);
-      const rewardValue3 = toUnit(6000);
-      await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue2);
-      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue3);
+      await rewardsToken0Owner.transfer(stakingRewards.address, rewardValue0);
+      await rewardsToken1Owner.transfer(stakingRewards.address, rewardValue0);
       await stakingRewards
         .connect(mockRewardsDistributionAddress)
-        .notifyRewardAmount(rewardValue2, rewardValue3);
+        .notifyRewardAmount(rewardValue0, rewardValue1);
 
       await fastForward(month);
 
-      console.log(await stakingRewards.rewardRate());
-      console.log(await stakingRewards.earned(deployerAccount.address));
+      const rewardRate1 = await stakingRewards.rewardRate();
+      const earned1 = await stakingRewards.earned(deployerAccount.address);
+
+      assert.bnEqual(rewardRate0[0], rewardRate1[0]);
+      assert.bnEqual(rewardRate0[1], rewardRate1[1]);
+      assert.bnEqual(earned1[0].sub(earned0[0]), earned0[0]);
+      assert.bnEqual(earned1[1].sub(earned0[1]), earned0[1]);
     });
   });
 });

--- a/test/StakingRewards.ts
+++ b/test/StakingRewards.ts
@@ -327,7 +327,6 @@ describe("StakingRewards contract", function () {
           (await provider.getBlock(tx.blockNumber)).timestamp
         )
           .div(DAY * 7)
-          .add(1)
           .mul(DAY * 7);
         const lastTimeReward = await stakingRewards.lastTimeRewardApplicable();
 

--- a/test/StakingRewards.ts
+++ b/test/StakingRewards.ts
@@ -1558,6 +1558,19 @@ describe("StakingRewards contract", function () {
 
       assert.bnEqual(rewardRate0, rewardRate1);
       assert.bnEqual(earned1.sub(earned0), earned0);
+
+      const rewardsTokenBalance = await rewardsToken.balanceOf(
+        deployerAccount.address
+      );
+
+      await stakingRewards.connect(deployerAccount).getReward();
+
+      assert.bnEqual(
+        (await rewardsToken.balanceOf(deployerAccount.address)).sub(
+          rewardsTokenBalance
+        ),
+        earned1
+      );
     });
   });
 });

--- a/test/StakingRewards.ts
+++ b/test/StakingRewards.ts
@@ -436,7 +436,7 @@ describe("StakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       const rewardPerToken = await stakingRewards.rewardPerToken();
 
@@ -649,7 +649,7 @@ describe("StakingRewards contract", function () {
 
       const earned = await stakingRewards.earned(deployerAccount.address);
 
-      assert.bnGt(earned, toUnit("999.999"));
+      assert.bnGt(earned, toUnit("499.999"));
     });
 
     it("should be same after emission hit + 1 day", async () => {
@@ -695,7 +695,7 @@ describe("StakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       const earned = await stakingRewards.earned(deployerAccount.address);
 
@@ -735,7 +735,7 @@ describe("StakingRewards contract", function () {
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 1);
+      await fastForward(DAY * 7);
 
       await stakingRewards.connect(owner).stake(totalToStake);
 
@@ -811,7 +811,7 @@ describe("StakingRewards contract", function () {
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 22);
+      await fastForward(DAY * 28);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
 
       assertBNGreaterThan(deployerEarned, rewardValue.mul(98).div(100));
@@ -853,7 +853,7 @@ describe("StakingRewards contract", function () {
 
       assertBNLessThan(deployerEarned, rewardValue.mul(3).div(4));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 2);
 
       assert.bnEqual(
         deployerEarned,
@@ -887,7 +887,7 @@ describe("StakingRewards contract", function () {
 
       assertBNLessThan(deployerEarned, rewardValue.mul(1).div(2));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 2);
 
       assert.bnEqual(
         deployerEarned,
@@ -922,7 +922,7 @@ describe("StakingRewards contract", function () {
 
       assertBNLessThan(deployerEarned, rewardValue.mul(1).div(4));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 2);
 
       assert.bnEqual(
         deployerEarned,
@@ -944,16 +944,16 @@ describe("StakingRewards contract", function () {
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue);
 
-      await fastForward(DAY * 22);
+      await fastForward(DAY * 18);
 
       await stakingRewards.connect(deployerAccount).stake(totalToStake);
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 1);
       let deployerEarned = await stakingRewards.earned(deployerAccount.address);
       console.log(deployerEarned.toString());
-      assert.bnEqual(deployerEarned, rewardValue.mul(0).div(4));
+      assert.bnEqual(deployerEarned, BigNumber.from(0));
 
-      await fastForward(DAY * 7);
+      await fastForward(DAY * 1);
 
       assert.bnEqual(
         deployerEarned,
@@ -1492,17 +1492,27 @@ describe("StakingRewards contract", function () {
 
     it("Reverts if the provided reward is greater than the balance, plus rolled-over balance.", async () => {
       const rewardValue = toUnit(1000);
-      await rewardsTokenOwner.transfer(
-        localStakingRewards.address,
-        rewardValue
+      let rewardsTokenBalance = await rewardsToken.balanceOf(
+        localStakingRewards.address
       );
+      if (rewardValue.gt(rewardsTokenBalance)) {
+        await rewardsTokenOwner.transfer(
+          localStakingRewards.address,
+          rewardValue.sub(rewardsTokenBalance)
+        );
+      }
       localStakingRewards
         .connect(mockRewardsDistributionAddress)
         .notifyRewardAmount(rewardValue);
-      await rewardsTokenOwner.transfer(
-        localStakingRewards.address,
-        rewardValue
+      rewardsTokenBalance = await rewardsToken.balanceOf(
+        localStakingRewards.address
       );
+      if (rewardValue.gt(rewardsTokenBalance)) {
+        await rewardsTokenOwner.transfer(
+          localStakingRewards.address,
+          rewardValue.sub(rewardsTokenBalance)
+        );
+      }
       // Now take into account any leftover quantity.
       await assert.revert(
         localStakingRewards


### PR DESCRIPTION
- Removed these lines so rewards aren't reset when withdrawing before `periodFinish`
  - https://github.com/ribbon-finance/governance/blob/0170758602d8e075735be6c618d3dcfbf39d69aa/contracts/tvl-staking/RibbonStakingRewards.sol#L153
  - https://github.com/ribbon-finance/governance/blob/0170758602d8e075735be6c618d3dcfbf39d69aa/contracts/tvl-staking/RibbonDualStakingRewards.sol#L209
- Removed `startEmission` / `setStartEmission`
- Tested monthly rolling reward programs (with 26 day `rewardsDuration`)